### PR TITLE
Fixed Error: Mic enabled while TTS was on, then turns off.

### DIFF
--- a/views/index.html
+++ b/views/index.html
@@ -96,9 +96,12 @@
         }
     
         function enableTTS() {
-            if (isSpeaking) return;
-
-            speak("Home Page - say help for list of commands");
+            // Trigger TTS every time the page loads
+            speak("Home Page - say help for list of commands.")
+            .then(() => {
+                // Start speech recognition after TTS is spoken
+                startSpeechRecognition();
+            });
         }
 
         window.onload = () => {
@@ -109,8 +112,7 @@
             } else {
                 console.error("Button not found! Make sure your HTML is correctly loaded.");
             }
-            isRecognitionActive = true; // <-- Always active now
-            startSpeechRecognition();
+            isRecognitionActive = true;
         };
 
         // Remove toggleSpeechRecognition completely

--- a/views/tasks.html
+++ b/views/tasks.html
@@ -61,10 +61,10 @@
                                 recognition.start();
                             }
                             resolve();
-                            };
+                        };
                         
-                            // Short timeout to ensure the engine is ready
-                            setTimeout(() => synth.speak(utterance), 100);
+                        // Short timeout to ensure the engine is ready
+                        setTimeout(() => synth.speak(utterance), 100);
                     }, 200);
                 });
             }


### PR DESCRIPTION
**Fix:** One line of code caused the issue. In index.html `startSpeechRecognition();`, at the end of the `window.onload` function, the function call caused it to enable the mic while TTS was speaking right when the page loaded then the speak function would turn it off after TTS was done.

**Testing:** Tested all commands with and without PTT enabled.

**Unrelated:** Changed `enableTTS()` to the more robust version that is in other files.