### PR TITLE
SyntaxError: The requested module './googleCalendarController.js' does not provide an export named 'formatDateTimeForGoogle'

### DIFF
--- a/server/controllers/googleCalendarController.js
+++ b/server/controllers/googleCalendarController.js
@@ -653,5 +653,6 @@ export {
   pushRemindersToGoogle, 
   removeGoogleReminders,
   createExtendedProperties,
-  extractExtendedProperties
+  extractExtendedProperties,
+  formatDateTimeForGoogle
 };


### PR DESCRIPTION
**Fix:** Added `formatDateTimeForGoogle` to googleCalendarController.js.

**Testing:** Ran program, no error.